### PR TITLE
Ensure left-leading / on requestUri is stripped

### DIFF
--- a/Routemaster.class.php
+++ b/Routemaster.class.php
@@ -84,7 +84,12 @@ abstract class Routemaster
 
         //strip base dir and query string from request URI
         $base = dirname($_SERVER['SCRIPT_NAME']);
-        $this->requestUri = preg_replace("|^$base/?|", '', parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH));
+
+        $requestUri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+        $requestUri = preg_replace("|^$base/?|", '', $requestUri);
+        $requestUri = ltrim($requestUri, '/'); //ensure left-leading "/" is stripped.
+
+        $this->requestUri = $requestUri;
         $this->_debug['routes'] = $this->routes();
         $this->_debug['requestUri'] = $this->requestUri;
 


### PR DESCRIPTION
Ensure left-leading / on requestUri is stripped
On some PHP setups this is not happening. This additional code ensures that it does.
Also cleaned up that part of the code to make it easier to understand the steps involved.