### PR TITLE
Sets global post to a WP_Post instead of an Oowp WordpressPost

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "description": "A routing plugin for WordPress",
   "minimum-stability": "stable",
   "license": "GPL-3.0",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "autoload": {
     "psr-4": {
       "Outlandish\\Wordpress\\Routemaster\\": "src/"

--- a/src/Oowp/OowpRouterHelper.php
+++ b/src/Oowp/OowpRouterHelper.php
@@ -91,12 +91,12 @@ class OowpRouterHelper extends RouterHelper
 			throw new RoutemasterException('Not found', 404);
 		}
 
-		$post = $query[0];
+		$oowpPost = $query[0];
+		$post = $oowpPost->get_post();
 
 		if ($redirectCanonical) {
-			$this->redirectCanonical($post);
+    			$this->redirectCanonical($oowpPost);
 		}
-
-		return $post;
+		return $oowpPost;
 	}
 }


### PR DESCRIPTION
This is in order to support several inbuilt wordpress functions - in particular those that rely on `get_post()`, but potentially others