### PR TITLE
Fixed bug where /wp-json/ routes were intercepted...

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -41,8 +41,9 @@ abstract class Router
 	 */
 	public function setup()
 	{
-        $requestUrl = $_SERVER['REQUEST_URI'];
-        $isJsonRequest =  strpos($requestUrl, '/wp-json') === 0 ;
+        $requestUrl = $_SERVER['REQUEST_SCHEME'] . "://" . $_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'];
+        $requestPath = str_replace(home_url(), "", $requestUrl);
+        $isJsonRequest =  strpos($requestPath, '/wp-json') === 0 ;
 
         if (is_admin() || !defined('WP_USE_THEMES') || $isJsonRequest) {
             //don't do any routing for admin pages or wp-json API requests


### PR DESCRIPTION
... if the site was not at the server root. e.g. localhost/example/wp-json/