### PR TITLE
Moved json-api logic from setup() to route() as per suggestion from p…

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -41,14 +41,7 @@ abstract class Router
 	 */
 	public function setup()
 	{
-        $requestUrl = $_SERVER['REQUEST_URI'];
-        $isJsonRequest =  strpos($requestUrl, '/wp-json') === 0 ;
-
-        if (is_admin() || !defined('WP_USE_THEMES') || $isJsonRequest) {
-            //don't do any routing for admin pages or wp-json API requests
-			//don't do any routing for admin pages
-			return;
-		} elseif (!get_option('permalink_structure')) {
+        if (!get_option('permalink_structure')) {
 			$url = admin_url('options-permalink.php');
 			die("Permalinks must be <a href='$url'>enabled</a>.");
 		}
@@ -126,6 +119,12 @@ abstract class Router
         $requestUri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
         $requestUri = preg_replace("|^$base/?|", '', $requestUri);
         $requestUri = ltrim($requestUri, '/'); //ensure left-leading "/" is stripped.
+	    $isJsonRequest =  strpos($requestUri, 'wp-json') === 0 ;
+
+	    if (is_admin() || !defined('WP_USE_THEMES') || $isJsonRequest) {
+		    //don't do any routing for admin pages or wp-json API requests
+		    return;
+	    }
 
 		$allRoutes = $this->buildRoutes();
 


### PR DESCRIPTION
Fixed bug with wp-json requests being interrupted on some sites. Updated it so that it doesn't rely on $_SERVER['request_uri'] which isn't always set

Moved json-api logic from setup() to route() as per suggestion from previous merge request

