### PR TITLE
PROSPECT-526 - Add support for preview. By passing the requestURI on preview

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -116,18 +116,18 @@ abstract class Router
     {
         global $wp_query;
 
-        //strip base dir and query string from request URI
-        $base = dirname($_SERVER['SCRIPT_NAME']);
-
-        $requestUri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
-        $requestUri = preg_replace("|^$base/?|", '', $requestUri);
-        $requestUri = ltrim($requestUri, '/'); //ensure left-leading "/" is stripped.
-	    $isJsonRequest =  strpos($requestUri, 'wp-json') === 0 ;
-
-        //adding support for preview. PROSPECT-526
-        if (isset($_REQUEST['preview']) && $_REQUEST['preview']) {
+        if ( ! empty($_REQUEST['preview'])) {
+            //adding support for preview. PROSPECT-526
             $requestUri = $_SERVER['REQUEST_URI'];
+        } else {
+            //strip base dir and query string from request URI
+            $base       = dirname($_SERVER['SCRIPT_NAME']);
+            $requestUri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+            $requestUri = preg_replace("|^$base/?|", '', $requestUri);
+            $requestUri = ltrim($requestUri, '/'); //ensure left-leading "/" is stripped.
         }
+
+        $isJsonRequest = strpos($requestUri, 'wp-json') === 0;
 
 	    if ($isJsonRequest) {
 		    //don't do any routing wp-json API requests

--- a/src/Router.php
+++ b/src/Router.php
@@ -124,6 +124,11 @@ abstract class Router
         $requestUri = ltrim($requestUri, '/'); //ensure left-leading "/" is stripped.
 	    $isJsonRequest =  strpos($requestUri, 'wp-json') === 0 ;
 
+        //adding support for preview. PROSPECT-526
+        if ( ! get_query_var('preview')) {
+            $requestUri = $_SERVER['REQUEST_URI'];
+        }
+
 	    if ($isJsonRequest) {
 		    //don't do any routing wp-json API requests
 		    return;

--- a/src/Router.php
+++ b/src/Router.php
@@ -146,6 +146,13 @@ abstract class Router
 		$matchingRoutes = [];
 		foreach ($allRoutes as $route) {
 			if (preg_match($route->pattern, $this->requestUri, $matches)) {
+                if ( ! get_query_var('preview')) {
+                    // If this is a preview, the matches resulted in an ID.
+                    if (is_numeric($matches[1])) {
+                        //replace it with the slug
+                        $matches[1] = get_post_field('post_name', $matches[1]);
+                    }
+                }
 				array_shift($matches); //remove first element
 				$matchingRoutes[] = [
 					'route' => $route,

--- a/src/Router.php
+++ b/src/Router.php
@@ -146,13 +146,6 @@ abstract class Router
 		$matchingRoutes = [];
 		foreach ($allRoutes as $route) {
 			if (preg_match($route->pattern, $this->requestUri, $matches)) {
-                if ( ! get_query_var('preview')) {
-                    // If this is a preview, the matches resulted in an ID.
-                    if (is_numeric($matches[1])) {
-                        //replace it with the slug
-                        $matches[1] = get_post_field('post_name', $matches[1]);
-                    }
-                }
 				array_shift($matches); //remove first element
 				$matchingRoutes[] = [
 					'route' => $route,

--- a/src/Router.php
+++ b/src/Router.php
@@ -125,7 +125,7 @@ abstract class Router
 	    $isJsonRequest =  strpos($requestUri, 'wp-json') === 0 ;
 
         //adding support for preview. PROSPECT-526
-        if ( ! get_query_var('preview')) {
+        if (isset($_REQUEST['preview']) && $_REQUEST['preview']) {
             $requestUri = $_SERVER['REQUEST_URI'];
         }
 


### PR DESCRIPTION
Issue PROSPECT-526
Preview urls were of the format: `/?post_type=news&p=5040&preview=true` 
These were not matching any of the routes regex expressions, so the frontpage template is being used. 
With this change the uri data keep on getting passed. It still uses the default template. If we want to use the specific template of each custom pagetype, we would have to add in the OlRouter construct something like: 
``` $this->addRoute('/\/\?post_type=news\&p=([0-9]*)\&preview=true/', 'newsItemPage');```


